### PR TITLE
Support for ~operator to match with regexps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is what the parser currently supports not necessarily what can be supported
 |✅| **-**_key_**:**_valuefragment_      |              |
 |✅| _key_                              |              | 
 |✅| _key_**=**_value_                  |              | 
+|✅| _key_**~**_regexp_                 | in JOSM since 16260 |
 |✅| *key*__=*__                         |              | 
 |✅| _key_**=**                          |              | 
 |✅| __*=__*value*                       |              | 
@@ -52,7 +53,7 @@ This is what the parser currently supports not necessarily what can be supported
 |✅|__timestamp:__                       |              | 
 |✅|__nodes:__*range*                    |              |
 |✅|__ways:__*range*                     |              |
-|✅|__members:__*range*                  | extension    |
+|✅|__members:__*range*                  | in JOSM since 16581 |
 |✅|__tags:__*range*                     |              | 
 |✅|__role:__*role*                      |              |
 |✅|__areasize:__*range*                 |              | 

--- a/src/main/java/ch/poole/osm/josmfilterparser/JosmFilterParser.jj
+++ b/src/main/java/ch/poole/osm/josmfilterparser/JosmFilterParser.jj
@@ -143,7 +143,7 @@ TOKEN:
   < NODE : "node" >
 | < WAY : "way" >
 | < RELATION : "relation" >
-| < FRAGMENT_LITERAL : (~[ "\"", "\\", "|", " ", "\t", "<", "=", ">", "(", ")" ])+ > 
+| < FRAGMENT_LITERAL : (~[ "\"", "\\", "|", " ", "\t", "<", "=", ">", "~", "(", ")" ])+ > 
 }
 
 < DEFAULT >
@@ -162,7 +162,7 @@ TOKEN :
 | < ALLINDOWNLOADEDAREA : "allindownloadedarea" >
 | < CHILD : "child" >
 | < PARENT : "parent" >
-| < LITERAL : (~[ "-", "\"", "\\", "|", " ", "\t", "<", "=", ">", ":", "(", ")" ])+ >
+| < LITERAL : (~[ "-", "\"", "\\", "|", " ", "\t", "<", "=", ">", "~", ":", "(", ")" ])+ >
 }
           
 < DEFAULT >
@@ -172,6 +172,7 @@ TOKEN :
 | < EQ : "=" > : DEFAULT
 | < GT : ">" > : DEFAULT
 | < LT : "<" > : DEFAULT
+| < TILDE : "~" > : DEFAULT
 | < DOUBLECOLON : ":" > : FRAGMENT_STRING_STATE
 }
 
@@ -527,6 +528,7 @@ Condition match() :
             op = < EQ >
           | op = < GT >
           | op = < LT >
+          | op = < TILDE >
           )
           (< WS >)*
         )

--- a/src/test/java/ch/poole/osm/josmfilterparser/JosmFilterIntegrationTest.java
+++ b/src/test/java/ch/poole/osm/josmfilterparser/JosmFilterIntegrationTest.java
@@ -86,6 +86,26 @@ public class JosmFilterIntegrationTest {
     }
 
     /**
+     * Test tag matching with ~operator (value regexps)
+     */
+    @Test
+    public void matchValueRegexpTest() {
+
+        Map<String, String> tags = new HashMap<>();
+        tags.put("test1", "grrr");
+        tags.put("test", "grrr");
+
+        Condition c = parse("test1~.*", false);
+        assertTrue(c.eval(Type.NODE, null, tags));
+
+        c = parse("test1~g..r", false);
+        assertTrue(c.eval(Type.NODE, null, tags));
+
+        c = parse("test1~grRr", false);
+        assertFalse(c.eval(Type.NODE, null, tags));
+    }
+
+    /**
      * Test alphanumeric value comparisons
      */
     @Test


### PR DESCRIPTION
This is needed for overpass API queries and was added to JOSM a bit back.