### PR TITLE
Make parsing of constructs containing double colons more robust

### DIFF
--- a/src/main/java/ch/poole/osm/josmfilterparser/And.java
+++ b/src/main/java/ch/poole/osm/josmfilterparser/And.java
@@ -27,6 +27,14 @@ public class And implements Condition, LogicalOperator, Serializable {
     public boolean eval(Type type, Meta meta, Map<String, String> tags) {
         return c1.eval(type, meta, tags) && c2.eval(type, meta, tags);
     }
+    
+    @Override
+    public boolean debugEval(Type type, Meta meta, Map<String, String> tags) {
+        boolean r1 = c1.debugEval(type, meta, tags);
+        boolean r2 = c2.debugEval(type, meta, tags);
+        System.out.println("DEBUG: AND " + r1 + " " + r2);
+        return r1 && r2;
+    }
 
     @Override
     public void reset() {

--- a/src/main/java/ch/poole/osm/josmfilterparser/Child.java
+++ b/src/main/java/ch/poole/osm/josmfilterparser/Child.java
@@ -29,6 +29,17 @@ public class Child implements Condition, LogicalOperator, Serializable {
         }
         return meta.isChild(type, meta, parents);
     }
+    
+    @Override
+    public boolean debugEval(Type type, Meta meta, Map<String, String> tags) {
+        if (parents == null) {
+            parents = meta.getMatchingElements(c);
+        }
+        System.out.println("DEBUG CHILD " + parents.size() + " PARENTS");
+        boolean r = meta.isChild(type, meta, parents);
+        System.out.println("DEBUG CHILD " + r);
+        return r;
+    }
 
     @Override
     public void reset() {

--- a/src/main/java/ch/poole/osm/josmfilterparser/Condition.java
+++ b/src/main/java/ch/poole/osm/josmfilterparser/Condition.java
@@ -25,6 +25,10 @@ public interface Condition extends Serializable {
      */
     public boolean eval(@NotNull Type type, @Nullable Meta meta, @Nullable Map<String, String> tags);
 
+    default boolean debugEval(@NotNull Type type, @Nullable Meta meta, @Nullable Map<String, String> tags) {
+        return eval(type,meta,tags);
+    }
+
     /**
      * Reset any state created during evaluation
      */

--- a/src/main/java/ch/poole/osm/josmfilterparser/JosmFilterParser.jj
+++ b/src/main/java/ch/poole/osm/josmfilterparser/JosmFilterParser.jj
@@ -159,7 +159,14 @@ TOKEN:
 | < WAY : "way" > { SwitchTo(state.pop()); }
 | < RELATION : "relation" > { SwitchTo(state.pop()); }
 | < FRAGMENT_LITERAL : (~[ "\"", "\\", "|", " ", "\t", "<", "=", ">", "~", "(", ")", "?" ])+ >
-| < FRAGMENT_LITERAL_END :  ([ "\"", "\\", "|", " ", "\t", "<", "=", ">", "~", "(", ")", "?" ])+> { SwitchTo(state.pop()); }
+  // the following is unlikely to do anything reasonable
+| < FRAGMENT_LITERAL_END :  ([ "\"", "\\", "|", "<", "=", ">", "~", "(", ")", "?" ])> { SwitchTo(state.pop()); }
+}
+
+< FRAGMENT_STRING_STATE >
+TOKEN:
+{ // return a WS token, this allows the parser to ignore this specific token
+  < FRAGMENT_LITERAL_WS_END : ([ " ", "\t" ])> { matchedToken.image = "<WS>"; matchedToken.kind = WS; SwitchTo(state.pop()); }
 }
 
 < DEFAULT >
@@ -191,7 +198,7 @@ TOKEN :
 | < LT : "<" > : DEFAULT
 | < TILDE : "~" > : DEFAULT
 | < QUESTIONMARK : "?" > : DEFAULT
-| < DOUBLECOLON : ":" > : DEFAULT // { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < DOUBLECOLON : ":" > : DEFAULT
 }
 
 < DEFAULT >
@@ -230,7 +237,7 @@ String fragmentLiteral() :
 {
   Token t;
 }
-{    t = < FRAGMENT_LITERAL > 
+{    t = < FRAGMENT_LITERAL >
     {
         return t.image;
     }
@@ -565,12 +572,12 @@ Condition match() :
       LOOKAHEAD(functionWithArgument() (fragmentLiteral() | quotedLiteral() | < NODE > | < WAY > | < RELATION >))
       (     
         f1 = functionWithArgument()
-        (           s1 = fragmentLiteral()
+        (          s1 = fragmentLiteral()
         | s1 = quotedLiteral()
         | v = < NODE >
         | v = < WAY >
         | v = < RELATION >
-        )    
+        )
       )
     )
     (   

--- a/src/main/java/ch/poole/osm/josmfilterparser/JosmFilterParser.jj
+++ b/src/main/java/ch/poole/osm/josmfilterparser/JosmFilterParser.jj
@@ -32,9 +32,9 @@ options
   FORCE_LA_CHECK = true;
   CHOICE_AMBIGUITY_CHECK = 2;
   OTHER_AMBIGUITY_CHECK = 2;
-  DEBUG_PARSER = false;
-  DEBUG_LOOKAHEAD = false;
-  DEBUG_TOKEN_MANAGER = false;
+  DEBUG_PARSER = true;
+  DEBUG_LOOKAHEAD = true;
+  DEBUG_TOKEN_MANAGER = true;
   UNICODE_INPUT = true;
 }
 
@@ -114,7 +114,7 @@ TOKEN :
 | < QUOTED_STRING_CHAR : ~[ "\"", "\\" ] >
 }
 
-< DEFAULT, FRAGMENT_STRING_STATE >
+< DEFAULT >
 TOKEN :
 {
   < WS : [ " ", "\t" ] > : DEFAULT
@@ -133,32 +133,33 @@ TOKEN [IGNORE_CASE]:
 < DEFAULT >
 TOKEN :
 { 
-  < TYPE : "type:" > : FRAGMENT_STRING_STATE
-| < PRESET : "preset:" > : FRAGMENT_STRING_STATE
-| < NODES : "nodes:" > : FRAGMENT_STRING_STATE
-| < WAYS : "ways:" > : FRAGMENT_STRING_STATE
-| < TAGS : "tags:" > : FRAGMENT_STRING_STATE
-| < MEMBERS : "members:" > : FRAGMENT_STRING_STATE
-| < ROLE : "role:" > : FRAGMENT_STRING_STATE
-| < AREASIZE : "areasize:" > : FRAGMENT_STRING_STATE
-| < WAYLENGTH : "waylength:" > : FRAGMENT_STRING_STATE
-| < USER : "user:" > : FRAGMENT_STRING_STATE
-| < ID : "id:" > : FRAGMENT_STRING_STATE
-| < VERSION : "version:" > : FRAGMENT_STRING_STATE
-| < CHANGESET : "changeset:" > : FRAGMENT_STRING_STATE
-| < TIMESTAMP : "timestamp:" > : FRAGMENT_STRING_STATE
-| < HASROLE : "hasRole:" > : FRAGMENT_STRING_STATE
-| < NTH : "nth:" > : FRAGMENT_STRING_STATE
-| < NTHPERCENT : "nth%:" > : FRAGMENT_STRING_STATE
+  < TYPE : "type:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < PRESET : "preset:" > {state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < NODES : "nodes:" > {state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < WAYS : "ways:" > {state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < TAGS : "tags:" > {state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < MEMBERS : "members:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < ROLE : "role:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < AREASIZE : "areasize:" > {state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < WAYLENGTH : "waylength:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < USER : "user:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < ID : "id:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < VERSION : "version:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < CHANGESET : "changeset:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < TIMESTAMP : "timestamp:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < HASROLE : "hasRole:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < NTH : "nth:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
+| < NTHPERCENT : "nth%:" > { state.push(curLexState); }: FRAGMENT_STRING_STATE
 }
 
 < FRAGMENT_STRING_STATE >
 TOKEN:
 {
-  < NODE : "node" >
-| < WAY : "way" >
-| < RELATION : "relation" >
-| < FRAGMENT_LITERAL : (~[ "\"", "\\", "|", " ", "\t", "<", "=", ">", "~", "(", ")", "?" ])+ > 
+  < NODE : "node" > { SwitchTo(state.pop()); }
+| < WAY : "way" > { SwitchTo(state.pop()); }
+| < RELATION : "relation" > { SwitchTo(state.pop()); }
+| < FRAGMENT_LITERAL : (~[ "\"", "\\", "|", " ", "\t", "<", "=", ">", "~", "(", ")", "?" ])+ >
+| < FRAGMENT_LITERAL_END :  ([ "\"", "\\", "|", " ", "\t", "<", "=", ">", "~", "(", ")", "?" ])+> { SwitchTo(state.pop()); }
 }
 
 < DEFAULT >
@@ -190,7 +191,7 @@ TOKEN :
 | < LT : "<" > : DEFAULT
 | < TILDE : "~" > : DEFAULT
 | < QUESTIONMARK : "?" > : DEFAULT
-| < DOUBLECOLON : ":" > : FRAGMENT_STRING_STATE
+| < DOUBLECOLON : ":" > : DEFAULT // { state.push(curLexState); }: FRAGMENT_STRING_STATE
 }
 
 < DEFAULT >
@@ -229,11 +230,10 @@ String fragmentLiteral() :
 {
   Token t;
 }
-{
-  t = < FRAGMENT_LITERAL >
-  {
-    return t.image;
-  }
+{    t = < FRAGMENT_LITERAL > 
+    {
+        return t.image;
+    }
 }
 
 /**
@@ -570,7 +570,7 @@ Condition match() :
         | v = < NODE >
         | v = < WAY >
         | v = < RELATION >
-        )
+        )    
       )
     )
     (   
@@ -612,7 +612,7 @@ Condition match() :
             s2Quoted = true;
           }
         | 
-          s2 = fragmentLiteral()
+          s2 = literal()
         )?
       )
     |

--- a/src/main/java/ch/poole/osm/josmfilterparser/Match.java
+++ b/src/main/java/ch/poole/osm/josmfilterparser/Match.java
@@ -315,55 +315,54 @@ public class Match implements Condition, Serializable {
     @Override
     public String toOverpass() {
         StringBuilder builder = new StringBuilder();
-        if (op != null) {
-            builder.append("[");
-            if (value != null && !"".equals(value) && !valueAsterix) {
-                builder.append(keyAsterix ? TILDE + REG_EXP_ANY : quoteOverpass(key));
-                negate(builder);
-                switch (op) {
-                case EQUALS:
-                    if (keyAsterix) {
-                        builder.append(TILDE);
-                        builder.append("\"^" + value + "$\"");
-                    } else {
-                        builder.append(EQUALS);
-                        builder.append(quoteOverpass(value));
-                    }
-                    break;
-                case TILDE:
-                    builder.append(TILDE);
-                    builder.append("\"" + value + "\"");
-                    break;
-                default:
-                    throw new UnsupportedOperationException(tr("op_with_value_not_supported", op));
-                }
-            } else {
-                switch (op) {
-                case EQUALS:
-                    builder.append(quoteOverpass(key));
-                    negate(builder);
-                    builder.append(TILDE);
-                    builder.append(valueAsterix ? REG_EXP_ANY : "\"^$\"");
-                    break;
-                case DOUBLECOLON:
-                    negate(builder);
-                    builder.append(quoteOverpass(key));
-                    // exact match already done
-                    break;
-                case QUESTIONMARK:
-                    builder.append(quoteOverpass(key));
-                    negate(builder);
-                    builder.append(TILDE);
-                    builder.append("\"^(true|yes|1|on)$\"");
-                    break;
-                default:
-                    throw new UnsupportedOperationException(tr("op_without_value_not_supported", op));
-                }
-            }
-            builder.append("]");
-        } else {
+        if (op == null) {
             throw new UnsupportedOperationException(tr("substring_match_not_supported"));
         }
+        builder.append("[");
+        if (value != null && !"".equals(value) && !valueAsterix) {
+            builder.append(keyAsterix ? TILDE + REG_EXP_ANY : quoteOverpass(key));
+            negate(builder);
+            switch (op) {
+            case EQUALS:
+                if (keyAsterix) {
+                    builder.append(TILDE);
+                    builder.append("\"^" + value + "$\"");
+                } else {
+                    builder.append(EQUALS);
+                    builder.append(quoteOverpass(value));
+                }
+                break;
+            case TILDE:
+                builder.append(TILDE);
+                builder.append("\"" + value + "\"");
+                break;
+            default:
+                throw new UnsupportedOperationException(tr("op_with_value_not_supported", op));
+            }
+        } else {
+            switch (op) {
+            case EQUALS:
+                builder.append(quoteOverpass(key));
+                negate(builder);
+                builder.append(TILDE);
+                builder.append(valueAsterix ? REG_EXP_ANY : "\"^$\"");
+                break;
+            case DOUBLECOLON:
+                negate(builder);
+                builder.append(quoteOverpass(key));
+                // exact match already done
+                break;
+            case QUESTIONMARK:
+                builder.append(quoteOverpass(key));
+                negate(builder);
+                builder.append(TILDE);
+                builder.append("\"^(true|yes|1|on)$\"");
+                break;
+            default:
+                throw new UnsupportedOperationException(tr("op_without_value_not_supported", op));
+            }
+        }
+        builder.append("]");
         return builder.toString();
     }
 
@@ -388,5 +387,10 @@ public class Match implements Condition, Serializable {
     @Override
     public Condition toDNF() {
         return this;
+    }
+
+    @Override
+    public String toDebugString() {
+        return "MATCH[op=" + op + " key=" + key + " value=" + value + "]";
     }
 }

--- a/src/main/java/ch/poole/osm/josmfilterparser/Not.java
+++ b/src/main/java/ch/poole/osm/josmfilterparser/Not.java
@@ -28,6 +28,13 @@ public class Not implements Condition, LogicalOperator, Serializable {
     }
 
     @Override
+    public boolean debugEval(Type type, Meta meta, Map<String, String> tags) {
+        boolean r = c1.debugEval(type, meta, tags);
+        System.out.println("DEBUG: NOT " + r);
+        return !r;
+    }
+
+    @Override
     public void reset() {
         c1.reset();
     }
@@ -49,7 +56,7 @@ public class Not implements Condition, LogicalOperator, Serializable {
 
     @Override
     public String toDebugString() {
-        return "-" + c1.toDebugString();
+        return "NOT[" + c1.toDebugString() + "]";
     }
 
     @Override

--- a/src/main/java/ch/poole/osm/josmfilterparser/Or.java
+++ b/src/main/java/ch/poole/osm/josmfilterparser/Or.java
@@ -33,6 +33,15 @@ public class Or implements Condition, LogicalOperator, Serializable {
     }
 
     @Override
+    public boolean debugEval(Type type, Meta meta, Map<String, String> tags) {
+        boolean r1 = c1.debugEval(type, meta, tags);
+        boolean r2 = c2.debugEval(type, meta, tags);
+        System.out.println("DEBUG: OR " + r1 + " " + r2);
+        return r1 || r2;
+    }
+
+    
+    @Override
     public void reset() {
         c1.reset();
         c2.reset();

--- a/src/test/java/ch/poole/osm/josmfilterparser/JosmFilterIntegrationTest.java
+++ b/src/test/java/ch/poole/osm/josmfilterparser/JosmFilterIntegrationTest.java
@@ -288,9 +288,22 @@ public class JosmFilterIntegrationTest {
      */
     @Test
     public void typeTest() {
-        Condition c = parse("type:node", false);
+        Condition c = parse("type:node ", false);
         Map<String, String> tags = new HashMap<>();
 
+        assertFalse(c.eval(Type.WAY, null, tags));
+        assertTrue(c.eval(Type.NODE, null, tags));
+    }
+    
+    /**
+     * Test testing for type of OSM element
+     */
+    @Test
+    public void typeTest2() {
+        Condition c = parse("(test type:node )", false);
+        System.out.println(c.toDebugString());
+        Map<String, String> tags = new HashMap<>();
+        tags.put("test", "grr");
         assertFalse(c.eval(Type.WAY, null, tags));
         assertTrue(c.eval(Type.NODE, null, tags));
     }
@@ -917,6 +930,16 @@ public class JosmFilterIntegrationTest {
         c = parse("node child highway", false);
         assertTrue(c instanceof And);
         assertTrue(((And) c).c2 instanceof Child);
+    }
+  
+    @Test
+    public void childTest2() {
+        TestMeta meta = new TestMeta();
+        meta.isChild = true;
+        Condition c = parse("-child (type:way highway: (oneway? OR oneway=\"-1\"))", false);
+        System.out.println(c.toDebugString());
+        assertTrue(c instanceof Not);
+        assertFalse(c.eval(Type.NODE, meta, null));
     }
 
     /**

--- a/src/test/java/ch/poole/osm/josmfilterparser/OverpassConversionTest.java
+++ b/src/test/java/ch/poole/osm/josmfilterparser/OverpassConversionTest.java
@@ -293,7 +293,7 @@ public class OverpassConversionTest {
         c = c.toDNF();
         assertEquals("(if:count_tags() == 1)", c.toOverpass());
     }
-
+    
     /**
      * Check tags
      */


### PR DESCRIPTION
Previously some constructs containing double colons would not parse correctly particularly if there was superfluous white space.
